### PR TITLE
Refactor: 사이드바에서 조회하면 유저 전체 목록을 useAllUserStore에서 가져오도록 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,15 @@ import Write from "./pages/Write";
 import ModifyProfile from "./pages/ModifyProfile";
 import SearchResult from "./pages/SearchResult";
 import { useEffect } from "react";
-import { getAllUsers } from "./api/user";
 import ModifyPassword from "./pages/ModifyPassword";
 import Private from "./layouts/Private";
+import { useAllUserStore } from "./store/allUserStore";
 
 function App() {
+  const fetchUsers = useAllUserStore((state) => state.fetchUsers);
+
   useEffect(() => {
-    getAllUsers();
+    fetchUsers();
   }, []);
 
   return (

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,13 +1,10 @@
-import { useAllUserStore } from "../store/allUserStore";
 import { useAuthStore } from "../store/authStore";
 import { axiosInstance } from "./axios";
 
 export const getAllUsers = async () => {
-  const setUsers = useAllUserStore.getState().setUsers;
-
   try {
     const { data } = await axiosInstance.get<User[]>("/users/get-users");
-    setUsers(data);
+    return data;
   } catch (error) {
     console.error(error);
   }

--- a/src/components/Profile/PostCardGridSection.tsx
+++ b/src/components/Profile/PostCardGridSection.tsx
@@ -4,7 +4,7 @@ export default function PostCardGridSection({ posts }: { posts: Post[] }) {
   return (
     <section className="grid grid-cols-2 gap-10 pb-10">
       {posts.map((post) => (
-        <PostCard key={post._id} post={post} />
+        <PostCard key={post._id} post={post} isSearch />
       ))}
     </section>
   );

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -25,8 +25,8 @@ export default function PostCard({ post }: PostCardProps) {
   const [postInformation, setPostInformation] = useState<CustomTitle | null>(
     null
   );
-  const { users } = useAllUserStore();
-  const { user } = useAuthStore();
+  const getUser = useAllUserStore((state) => state.getUser);
+  const user = useAuthStore((state) => state.user);
 
   useEffect(() => {
     parsePostTitle();
@@ -57,7 +57,7 @@ export default function PostCard({ post }: PostCardProps) {
           _id: user?._id,
         });
       } else {
-        const author = users.find((user) => user._id === post.author);
+        const author = getUser(post.author);
         setAuthor({
           fullName: author?.fullName || "",
           image: user?.image || "",

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from "../../store/authStore";
 
 interface PostCardProps {
   post: Post | SearchPost;
+  isSearch?: boolean;
 }
 
 interface Author {
@@ -17,7 +18,7 @@ interface Author {
   image: string | null;
 }
 
-export default function PostCard({ post }: PostCardProps) {
+export default function PostCard({ post, isSearch = false }: PostCardProps) {
   const navigate = useNavigate();
   const [likeInformation, setLikeInformation] = useState<Like | null>(null);
   const [likeCount, setLikeCount] = useState(post.likes.length);
@@ -26,12 +27,16 @@ export default function PostCard({ post }: PostCardProps) {
     null
   );
   const getUser = useAllUserStore((state) => state.getUser);
-  const user = useAuthStore((state) => state.user);
+  const loggedInUser = useAuthStore((state) => state.user);
 
   useEffect(() => {
     parsePostTitle();
-    setAuthorInformation();
     findLikeInformation();
+    if (isSearch) {
+      setSearchPostAuthor();
+    } else {
+      setPostAuthor();
+    }
   }, []);
 
   const parsePostTitle = () => {
@@ -48,36 +53,38 @@ export default function PostCard({ post }: PostCardProps) {
     }
   };
 
-  const setAuthorInformation = () => {
-    if (typeof post.author === "string") {
-      if (post.author === user?._id) {
-        setAuthor({
-          fullName: user?.fullName,
-          image: user?.image,
-          _id: user?._id,
-        });
-      } else {
-        const author = getUser(post.author);
-        setAuthor({
-          fullName: author?.fullName || "",
-          image: user?.image || "",
-          _id: post.author,
-        });
-      }
-    } else {
-      setAuthor({
-        fullName: post.author.fullName,
-        image: post.author.image,
-        _id: post.author._id,
-      });
-    }
+  const findLikeInformation = () => {
+    const likeInformation =
+      post.likes.find((like) => like.user === loggedInUser?._id) ?? null;
+    setLikeInformation(likeInformation);
   };
 
-  const findLikeInformation = () => {
-    // 좋아요 정보 찾기
-    const likeInformation =
-      post.likes.find((like) => like.user === user?._id) ?? null;
-    setLikeInformation(likeInformation);
+  const setPostAuthor = () => {
+    const author = post.author as User;
+    setAuthor({
+      fullName: author.fullName,
+      image: author.image,
+      _id: author._id,
+    });
+  };
+
+  const setSearchPostAuthor = () => {
+    const authorId = post.author as string;
+
+    if (authorId === loggedInUser?._id) {
+      setAuthor({
+        fullName: loggedInUser?.fullName,
+        image: loggedInUser?.image,
+        _id: loggedInUser?._id,
+      });
+    } else {
+      const author = getUser(authorId);
+      setAuthor({
+        fullName: author?.fullName || "",
+        image: author?.image || "",
+        _id: authorId,
+      });
+    }
   };
 
   const handleCardClick = () => {
@@ -112,7 +119,6 @@ export default function PostCard({ post }: PostCardProps) {
     }
   };
 
-  // 이전 테스트로 생성된 데이터로 인해 추가된 코드
   if (!postInformation) return null;
 
   return (

--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -4,6 +4,7 @@ import SearchIcon from "../assets/SearchIcon";
 import { useThemeStore } from "../store/themeStore";
 import { axiosInstance } from "../api/axios";
 import UserNavLink from "../components/common/UserNavLink";
+import { useAllUserStore } from "../store/allUserStore";
 
 interface Channel {
   _id: string;
@@ -20,7 +21,7 @@ export default function Sidebar() {
   const [searchName, setSearchName] = useState(""); // 검색할 이름 상태 관리
   const [searchResults, setSearchResults] = useState<User[]>([]); // 검색한 이름의 결과값 상태 관리
   const debounceTimeout = useRef<number | null>(null); // 디바운스 타이머 관리
-  const [allUsers, setAllUsers] = useState<User[]>([]); // 전체 유저 상태 관리
+  const allUsers = useAllUserStore((state) => state.users);
 
   const toggledInputFocused = () => setIsInputFocused((prev) => !prev);
 
@@ -32,16 +33,6 @@ export default function Sidebar() {
       console.log("유저 찾기 성공🎉", response.data);
     } catch (error) {
       console.error("Error:", error);
-    }
-  };
-
-  // 전체 유저값 갖고오기
-  const fetchAllUsers = async () => {
-    try {
-      const response = await axiosInstance.get("/users/get-users"); // 전체 유저 가져오는 API
-      setAllUsers(response.data); // 전체 유저 상태에 저장
-    } catch (error) {
-      console.error("전체 유저 가져오기 실패:", error);
     }
   };
 
@@ -58,7 +49,6 @@ export default function Sidebar() {
         setLoading(false);
       }
     };
-    fetchAllUsers();
     fetchChannels();
   }, []);
 

--- a/src/pages/MyProfile.tsx
+++ b/src/pages/MyProfile.tsx
@@ -15,6 +15,7 @@ export default function MyProfile() {
         setLoading(true);
         const response = await axiosInstance.get<User>("/auth-user");
         setUser(response.data);
+        console.log(response.data);
       } catch (err) {
         console.error(err);
         setError("사용자 정보를 불러오는 데 실패했습니다.");

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -92,7 +92,7 @@ export default function SearchResult() {
           {filteredPostResult.length > 0 ? (
             <div className="grid grid-cols-2 gap-10">
               {filteredPostResult.map((post) => (
-                <PostCard key={post._id} post={post} />
+                <PostCard key={post._id} post={post} isSearch />
               ))}
             </div>
           ) : (

--- a/src/store/allUserStore.ts
+++ b/src/store/allUserStore.ts
@@ -1,16 +1,23 @@
 import { create } from "zustand";
+import { getAllUsers } from "../api/user";
 
 // TODO: 유저 업데이트 로직 추가
 
 interface AllUserStore {
   users: User[];
-  setUsers: (users: User[]) => void;
-  addUser: (user: User) => void;
+  fetchUsers: () => Promise<void>;
+  getUser: (id: string) => User | undefined;
 }
 
-export const useAllUserStore = create<AllUserStore>((set) => ({
+export const useAllUserStore = create<AllUserStore>((set, get) => ({
   users: [],
-  setUsers: (users: User[]) => set({ users }),
-  addUser: (user: User) =>
-    set((state: AllUserStore) => ({ users: [...state.users, user] })),
+  fetchUsers: async () => {
+    try {
+      const data = await getAllUsers();
+      set({ users: data });
+    } catch (err) {
+      console.error(err);
+    }
+  },
+  getUser: (id: string) => get().users.find((user) => user._id === id),
 }));


### PR DESCRIPTION
## 수정 사항
- 사이드바에서, 첫 로딩 시에 전체 유저 목록을 조회하는 api가 중복적으로 호출되는 문제를 개선했습니다.
- allUserStore의 구조를 개선했습니다.
  - 전체 목록을 다시 조회할 일이 있지 않을까 싶어 api를 바로 받아 users에 저장시키는 로직으로 변경했습니다.
  - 유저 id를 받아 User 인터페이스 타입의 데이터를 반환해주는 메서드를 추가 및 반영했습니다.
