### PR TITLE
Fix: fullname 글자수 제한

### DIFF
--- a/src/components/Header/NotificationDropdown.tsx
+++ b/src/components/Header/NotificationDropdown.tsx
@@ -85,7 +85,7 @@ export default function NotificationDropdown({
   };
 
   return (
-    <div className="absolute px-8 py-3 left-0 top-11 w-[364px] z-50 bg-white dark:bg-gray-22 border dark:border-gray-ee/50 rounded-lg">
+    <div className="absolute px-8 py-3 left-0 top-11 w-[364px] z-40 bg-white dark:bg-gray-22 border dark:border-gray-ee/50 rounded-lg">
       <div className="flex justify-between items-center border-b border-gray-22 dark:border-gray-ee/50 py-2 mb-2.5">
         <p>알림</p>
         {notifications.length > 0 && (

--- a/src/components/Sidebar/ChannelList.tsx
+++ b/src/components/Sidebar/ChannelList.tsx
@@ -19,7 +19,7 @@ export default function ChannelList() {
               twMerge(
                 "flex items-center h-11 px-7 py-1 rounded-lg transition-colors",
                 isActive
-                  ? "bg-primary"
+                  ? "bg-primary dark:text-gray-22"
                   : "hover:bg-secondary dark:hover:text-gray-22"
               )
             }

--- a/src/components/Sidebar/UserNavLink.tsx
+++ b/src/components/Sidebar/UserNavLink.tsx
@@ -7,7 +7,7 @@ const UserNavLink = ({ user }: { user: User }) => {
       to={`/user/${user._id}`}
       className="group flex items-center gap-2.5 px-7 py-2 rounded-lg hover:bg-secondary dark:hover:text-gray-22 transition-all"
     >
-      <div className="relative w-7 h-7">
+      <div className="relative w-7 h-7 shrink-0">
         <img
           className="w-7 h-7 rounded-full profile profile-hover transition-all"
           src={user.image || "/logo.png"}
@@ -16,8 +16,7 @@ const UserNavLink = ({ user }: { user: User }) => {
           <div className="absolute bottom-0 left-0 w-2 h-2 bg-[#21e10f] rounded-full border border-white group-hover:border-secondary transition-colors" />
         )}
       </div>
-
-      <span>{user.fullName}</span>
+      <span className="line-clamp-1">{user.fullName}</span>
     </NavLink>
   );
 };

--- a/src/components/common/InputLabel.tsx
+++ b/src/components/common/InputLabel.tsx
@@ -4,13 +4,13 @@ import Input, { InputProps } from "./Input";
 interface InputLabelProps extends InputProps {
   label: string;
   id: string;
-  message: string;
+  errorMessage?: string;
   isWarning?: boolean;
 }
 export default function InputLabel({
   label,
   id,
-  message,
+  errorMessage,
   isWarning,
   ...props
 }: InputLabelProps) {
@@ -19,14 +19,14 @@ export default function InputLabel({
       <label htmlFor={id} className="text-sm text-gray-22">
         {label}
       </label>
-      <Input id={id} placeholder={message} {...props} />
+      <Input id={id} {...props} />
       <p
         className={twMerge(
-          "text-xs leading-7",
+          "text-xs h-4 mt-1",
           isWarning ? "text-red-accent" : "text-transparent select-none"
         )}
       >
-        {message}
+        {errorMessage ?? props.placeholder}
       </p>
     </fieldset>
   );

--- a/src/components/common/InputLabel.tsx
+++ b/src/components/common/InputLabel.tsx
@@ -26,7 +26,7 @@ export default function InputLabel({
           isWarning ? "text-red-accent" : "text-transparent select-none"
         )}
       >
-        {errorMessage ?? props.placeholder}
+        {errorMessage ?? props.placeholder + "."}
       </p>
     </fieldset>
   );

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -10,7 +10,7 @@ export default function Header() {
   const { user, isLoggedIn } = useAuthStore();
 
   return (
-    <header className="sticky top-0 border-b border-gray-ee dark:border-gray-ee/50 min-w-[1440px] w-full h-fit z-40 bg-white dark:bg-gray-22">
+    <header className="sticky top-0 border-b border-gray-ee dark:border-gray-ee/50 min-w-[1440px] w-full h-fit z-30 bg-white dark:bg-gray-22">
       <div className="flex justify-between items-center w-[1440px] h-[68px] px-10 mx-auto">
         <LogoButton />
         {isLoggedIn ? (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -52,7 +52,7 @@ export default function Login() {
             id="email"
             type="email"
             value={email.value}
-            message="이메일을 입력해주세요"
+            placeholder="이메일을 입력해주세요"
             isWarning={email.isWarning}
             onChange={(e) =>
               setEmail({ value: e.target.value, isWarning: false })
@@ -63,7 +63,7 @@ export default function Login() {
             id="password"
             type="password"
             value={password.value}
-            message="비밀번호를 입력해주세요"
+            placeholder="비밀번호를 입력해주세요"
             isWarning={password.isWarning}
             onChange={(e) =>
               setPassword({ value: e.target.value, isWarning: false })

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -46,7 +46,7 @@ export default function Login() {
     <section className="mx-auto flex screen-100vh items-center justify-center p-[70px]">
       <form onSubmit={handleSubmit} className="flex flex-col w-[400px]">
         <Logo className="mx-auto w-[100px] h-[100px] mb-10" />
-        <div className="flex flex-col gap-[10px]">
+        <div className="flex flex-col gap-4">
           <InputLabel
             label="이메일"
             id="email"

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -76,7 +76,7 @@ export default function Register() {
     <section className="mx-auto flex screen-100vh items-center justify-center p-[70px]">
       <form onSubmit={handleSubmit} className="flex flex-col w-[400px]">
         <Logo className="mx-auto w-[100px] h-[100px] mb-10" />
-        <div className="flex flex-col gap-[10px]">
+        <div className="flex flex-col gap-4">
           <InputLabel
             label="이름"
             id="name"

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -22,37 +22,36 @@ export default function Register() {
         isWarning: true,
         errorMessage: "이름을 입력해주세요.",
       });
-      return false;
-    }
-
-    if (!name.value.trim()) {
+    } else if (!name.value.trim()) {
       setName({
         ...name,
         isWarning: true,
         errorMessage: "공백만 있는 이름은 사용할 수 없습니다.",
       });
-      return false;
-    }
-
-    if (name.value.length > 7) {
+    } else if (name.value.length > 7) {
       setName({
         ...name,
         isWarning: true,
         errorMessage: "이름은 최대 7자까지만 입력할 수 있습니다.",
       });
-      return false;
     }
 
     if (!email.value) {
       setEmail({ ...email, isWarning: true });
-      return false;
     }
 
     if (!password.value) {
       setPassword({ ...password, isWarning: true });
-      return false;
     }
 
+    if (
+      !name.value ||
+      !name.value.trim() ||
+      name.value.length > 7 ||
+      !email.value ||
+      !password.value
+    )
+      return false;
     return true;
   };
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -6,25 +6,53 @@ import { useNavigate } from "react-router";
 import { axiosInstance } from "../api/axios";
 
 export default function Register() {
-  const [name, setName] = useState({ value: "", isWarning: false });
+  const [name, setName] = useState({
+    value: "",
+    isWarning: false,
+    errorMessage: "",
+  });
   const [email, setEmail] = useState({ value: "", isWarning: false });
   const [password, setPassword] = useState({ value: "", isWarning: false });
   const navigate = useNavigate();
-  const validate = () => {
-    const trimeedName = name.value.trim();
-    if (!trimeedName) {
-      setName({ ...name, value: trimeedName, isWarning: true });
-    }
-    if (!email.value) {
-      setEmail({ ...email, isWarning: true });
-    }
-    if (!password.value) {
-      setPassword({ ...password, isWarning: true });
-    }
 
-    if (!trimeedName || !email.value || !password.value) {
+  const validate = () => {
+    if (!name.value) {
+      setName({
+        ...name,
+        isWarning: true,
+        errorMessage: "이름을 입력해주세요.",
+      });
       return false;
     }
+
+    if (!name.value.trim()) {
+      setName({
+        ...name,
+        isWarning: true,
+        errorMessage: "공백만 있는 이름은 사용할 수 없습니다.",
+      });
+      return false;
+    }
+
+    if (name.value.length > 7) {
+      setName({
+        ...name,
+        isWarning: true,
+        errorMessage: "이름은 최대 7자까지만 입력할 수 있습니다.",
+      });
+      return false;
+    }
+
+    if (!email.value) {
+      setEmail({ ...email, isWarning: true });
+      return false;
+    }
+
+    if (!password.value) {
+      setPassword({ ...password, isWarning: true });
+      return false;
+    }
+
     return true;
   };
 
@@ -34,7 +62,7 @@ export default function Register() {
     try {
       axiosInstance.post("/signup", {
         email: email.value,
-        fullName: name.value,
+        fullName: name.value.trim(),
         password: password.value,
       });
       alert("회원가입 완료🎉");
@@ -55,10 +83,15 @@ export default function Register() {
             id="name"
             type="text"
             value={name.value}
-            message="이름을 입력해주세요"
+            placeholder="이름을 입력해주세요 (7자 이내)"
+            errorMessage={name.errorMessage}
             isWarning={name.isWarning}
             onChange={(e) =>
-              setName({ value: e.target.value, isWarning: false })
+              setName((prev) => ({
+                ...prev,
+                value: e.target.value,
+                isWarning: false,
+              }))
             }
           />
           <InputLabel
@@ -66,10 +99,14 @@ export default function Register() {
             id="email"
             type="email"
             value={email.value}
-            message="이메일을 입력해주세요"
+            placeholder="이메일을 입력해주세요"
             isWarning={email.isWarning}
             onChange={(e) =>
-              setEmail({ value: e.target.value, isWarning: false })
+              setEmail((prev) => ({
+                ...prev,
+                value: e.target.value,
+                isWarning: false,
+              }))
             }
           />
           <InputLabel
@@ -77,10 +114,14 @@ export default function Register() {
             id="password"
             type="password"
             value={password.value}
-            message="비밀번호를 입력해주세요"
+            placeholder="비밀번호를 입력해주세요"
             isWarning={password.isWarning}
             onChange={(e) =>
-              setPassword({ value: e.target.value, isWarning: false })
+              setPassword((prev) => ({
+                ...prev,
+                value: e.target.value,
+                isWarning: false,
+              }))
             }
           />
         </div>


### PR DESCRIPTION
## 작업 내용
### 구현 관련
- 회원가입 페이지, 유저 프로필 수정 페이지에서 글자수 제한을 걸어두었습니다.
- placeholder나 경고 메시지도 변경하였습니다.
- 경고 메시지가 케이스에 맞게 보여지도록 수정했습니다.
- 예방책으로 사이드바에서 유저 이름이 길어질 때 발생하던 이미지 찌그러짐 현상 수정과 닉네임이 한 줄로만 보이도록 변경했습니다.

### 스타일 관련
- 회원가입 페이지와 로그인 페이지에서 입력란 간격이 가까워 조금씩 더 간격을 주었습니다.

### 그외
- 정훈님 PR를 보니까 헤더와 드롭다운의 z-index에서 문제가 발생할 것 같아 한 단계씩 내렸습니다.
- 다크모드에서 사이드바의 active 메뉴 색상의 글자색을 어둡게 수정했습니다.