### PR TITLE
Feature: 프로필 페이지에 팔로잉한 사용자 목록 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "embla-carousel": "^8.5.1",
+    "embla-carousel-react": "^8.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^7.0.2",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -15,20 +15,13 @@ interface LoginResponse {
 
 // 로그인 API 함수
 export const loginApi = async (userInfo: LoginRequest) => {
+  const login = useAuthStore.getState().login;
   try {
     const { data } = await axiosInstance.post<LoginResponse>(
       "/login",
       userInfo
     );
-    useAuthStore.setState({
-      accessToken: data.token,
-      isLoggedIn: true,
-      user: {
-        _id: data.user._id,
-        image: data.user.image,
-        fullName: data.user.fullName,
-      },
-    });
+    login(data.token, data.user);
     return true;
   } catch (err) {
     if (err instanceof Error) console.error(err);

--- a/src/api/follow.ts
+++ b/src/api/follow.ts
@@ -1,0 +1,32 @@
+import { useAuthStore } from "../store/authStore";
+import { axiosInstance } from "./axios";
+
+export const postFollow = async (userId: string) => {
+  const addFollowing = useAuthStore.getState().addFollowing;
+  try {
+    const { data } = await axiosInstance.post<Follow>("/follow/create", {
+      userId,
+    });
+    addFollowing(data);
+    return data;
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+};
+
+export const deleteFollow = async (followId: string) => {
+  const deleteFollowing = useAuthStore.getState().deleteFollowing;
+  try {
+    await axiosInstance.delete("/follow/delete", {
+      data: {
+        id: followId,
+      },
+    });
+    deleteFollowing(followId);
+    return true;
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+};

--- a/src/assets/ArrowLeftIcon.tsx
+++ b/src/assets/ArrowLeftIcon.tsx
@@ -1,0 +1,20 @@
+export default function ArrowLeftIcon({
+  className,
+  color = "#1D1B20",
+}: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M14 18L8 12L14 6L15.4 7.4L10.8 12L15.4 16.6L14 18Z"
+        fill={color}
+      />
+    </svg>
+  );
+}

--- a/src/assets/ArrowRightIcon.tsx
+++ b/src/assets/ArrowRightIcon.tsx
@@ -1,0 +1,20 @@
+export default function ArrowRightIcon({
+  className,
+  color = "#1D1B20",
+}: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M12.6 12L8 7.4L9.4 6L15.4 12L9.4 18L8 16.6L12.6 12Z"
+        fill={color}
+      />
+    </svg>
+  );
+}

--- a/src/components/Profile/ArrowButton.tsx
+++ b/src/components/Profile/ArrowButton.tsx
@@ -1,0 +1,20 @@
+import { ComponentPropsWithoutRef } from "react";
+import { twMerge } from "tailwind-merge";
+
+type ArrowButtonProps = ComponentPropsWithoutRef<"button">;
+
+export default function ArrowButton({ className, ...props }: ArrowButtonProps) {
+  return (
+    <button
+      type="button"
+      className={twMerge(
+        "absolute z-10 top-1/2 transform -translate-y-1/2 rounded-full bg-white/90 drop-shadow-lg",
+        !props.disabled && "hover:bg-secondary ",
+        className
+      )}
+      {...props}
+    >
+      {props.children}
+    </button>
+  );
+}

--- a/src/components/Profile/FollowingSection.tsx
+++ b/src/components/Profile/FollowingSection.tsx
@@ -1,5 +1,10 @@
+import useEmblaCarousel from "embla-carousel-react";
 import { useAuthStore } from "../../store/authStore";
 import FollowingUser from "./FollowingUser";
+import ArrowLeftIcon from "../../assets/ArrowLeftIcon";
+import ArrowRightIcon from "../../assets/ArrowRightIcon";
+import { useCarouselButtons } from "../../hooks/useCarouselButtons";
+import ArrowButton from "./ArrowButton";
 
 interface FollowingSectionProps {
   fullName: string;
@@ -14,6 +19,18 @@ export default function FollowingSection({
 }: FollowingSectionProps) {
   const myFollowing = useAuthStore((state) => state.user)?.following;
 
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    align: "start",
+    slidesToScroll: 3,
+  });
+
+  const {
+    prevBtnDisabled,
+    nextBtnDisabled,
+    onPrevButtonClick,
+    onNextButtonClick,
+  } = useCarouselButtons(emblaApi);
+
   return (
     <section className="border-b border-gray-ee dark:border-gray-ee/50 w-full pb-10">
       <h2 className="text-2xl font-semibold mb-6">
@@ -25,17 +42,47 @@ export default function FollowingSection({
           </>
         )}
       </h2>
-      <div className="flex gap-12">
-        {followingList.map((followingUser) => (
-          <FollowingUser
-            key={followingUser._id}
-            user={followingUser}
-            myFollowInfo={myFollowing?.find(
-              (following) => following.user === followingUser.user
-            )}
-          />
-        ))}
-      </div>
+      {followingList.length === 0 ? (
+        <div className="flex items-center justify-center my-20">
+          <p className="text-lg text-center">팔로잉한 사용자가 없습니다.</p>
+        </div>
+      ) : (
+        <section className="relative px-7">
+          <ArrowButton
+            className="left-0"
+            onClick={onPrevButtonClick}
+            disabled={prevBtnDisabled}
+          >
+            <ArrowLeftIcon
+              className="w-8 h-8"
+              color={prevBtnDisabled ? "#C8C8C8" : "#222222"}
+            />
+          </ArrowButton>
+          <div ref={emblaRef} className="overflow-hidden">
+            <div className="flex gap-10">
+              {followingList.map((followingUser) => (
+                <FollowingUser
+                  key={followingUser._id}
+                  user={followingUser}
+                  myFollowInfo={myFollowing?.find(
+                    (following) => following.user === followingUser.user
+                  )}
+                />
+              ))}
+            </div>
+          </div>
+          <ArrowButton
+            className="right-0"
+            onClick={onNextButtonClick}
+            disabled={nextBtnDisabled}
+          >
+            <ArrowRightIcon
+              className="w-8 h-8"
+              color={nextBtnDisabled ? "#C8C8C8" : "#222222"}
+            />
+          </ArrowButton>
+        </section>
+      )}
     </section>
   );
 }

--- a/src/components/Profile/FollowingSection.tsx
+++ b/src/components/Profile/FollowingSection.tsx
@@ -1,0 +1,41 @@
+import { useAuthStore } from "../../store/authStore";
+import FollowingUser from "./FollowingUser";
+
+interface FollowingSectionProps {
+  fullName: string;
+  followingList: Follow[];
+  isMyProfile?: boolean;
+}
+
+export default function FollowingSection({
+  fullName,
+  followingList,
+  isMyProfile = false,
+}: FollowingSectionProps) {
+  const myFollowing = useAuthStore((state) => state.user)?.following;
+
+  return (
+    <section className="border-b border-gray-ee dark:border-gray-ee/50 w-full py-10">
+      <h2 className="text-2xl font-semibold mb-6">
+        {isMyProfile ? (
+          <>나의 팔로잉 목록</>
+        ) : (
+          <>
+            <span className="text-highlight">{fullName}</span>님의 팔로잉 목록
+          </>
+        )}
+      </h2>
+      <div className="flex gap-12">
+        {followingList.map((followingUser) => (
+          <FollowingUser
+            key={followingUser._id}
+            user={followingUser}
+            myFollowInfo={myFollowing?.find(
+              (following) => following.user === followingUser.user
+            )}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Profile/FollowingSection.tsx
+++ b/src/components/Profile/FollowingSection.tsx
@@ -15,7 +15,7 @@ export default function FollowingSection({
   const myFollowing = useAuthStore((state) => state.user)?.following;
 
   return (
-    <section className="border-b border-gray-ee dark:border-gray-ee/50 w-full py-10">
+    <section className="border-b border-gray-ee dark:border-gray-ee/50 w-full pb-10">
       <h2 className="text-2xl font-semibold mb-6">
         {isMyProfile ? (
           <>나의 팔로잉 목록</>

--- a/src/components/Profile/FollowingUser.tsx
+++ b/src/components/Profile/FollowingUser.tsx
@@ -72,7 +72,7 @@ export default function FollowingUser({ user, myFollowInfo }: FollowingUser) {
 
   return (
     <article
-      className="w-28 flex flex-col items-center gap-1 cursor-pointer"
+      className="w-28 flex flex-col items-center gap-1 cursor-pointer overflow-hidden"
       onClick={() => navigate(`/user/${user.user}`)}
     >
       <img
@@ -80,7 +80,9 @@ export default function FollowingUser({ user, myFollowInfo }: FollowingUser) {
         alt="프로필 이미지"
         className="w-24 h-24 profile rounded-full"
       />
-      <p className="text-base mb-1">{userInfo?.fullName}</p>
+      <p className="text-base text-center mb-1 w-full overflow-hidden text-ellipsis">
+        {userInfo?.fullName}
+      </p>
       <button
         className={twMerge(
           "w-full rounded-lg py-1 text-sm",

--- a/src/components/Profile/FollowingUser.tsx
+++ b/src/components/Profile/FollowingUser.tsx
@@ -1,0 +1,96 @@
+import { twMerge } from "tailwind-merge";
+import { useAllUserStore } from "../../store/allUserStore";
+import confirmAndNavigateToLogin from "../../utils/confirmAndNavigateToLogin";
+import { useNavigate } from "react-router";
+import { axiosInstance } from "../../api/axios";
+import { useState } from "react";
+import { useAuthStore } from "../../store/authStore";
+import { createNotification } from "../../api/notification";
+
+interface FollowingUser {
+  user: Follow;
+  myFollowInfo: Follow | undefined;
+}
+
+export default function FollowingUser({ user, myFollowInfo }: FollowingUser) {
+  const getUser = useAllUserStore((state) => state.getUser);
+  const deleteFollowing = useAuthStore((state) => state.deleteFollowing);
+  const addFollowing = useAuthStore((state) => state.addFollowing);
+  const userInfo = getUser(user.user);
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(false);
+
+  const handleFollow = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    e.stopPropagation();
+    confirmAndNavigateToLogin(navigate);
+
+    try {
+      setLoading(true);
+      const { data } = await axiosInstance.post<Follow>("/follow/create", {
+        userId: user.user,
+      });
+
+      addFollowing(data);
+
+      await createNotification({
+        notificationType: "FOLLOW",
+        notificationTypeId: data._id,
+        userId: data.user,
+      });
+    } catch (err) {
+      console.error("팔로우 요청 실패:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUnFollow = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    e.stopPropagation();
+    if (!myFollowInfo) {
+      console.error("언팔로우 불가: follow ID or access token 없음");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await axiosInstance.delete("/follow/delete", {
+        data: { id: myFollowInfo._id },
+      });
+
+      deleteFollowing(myFollowInfo._id);
+    } catch (err) {
+      console.error("언팔로우 요청 실패:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <article
+      className="w-28 flex flex-col items-center gap-1 cursor-pointer"
+      onClick={() => navigate(`/user/${user.user}`)}
+    >
+      <img
+        src={userInfo?.image ?? "/logo.png"}
+        alt="프로필 이미지"
+        className="w-24 h-24 profile rounded-full"
+      />
+      <p className="text-base mb-1">{userInfo?.fullName}</p>
+      <button
+        className={twMerge(
+          "w-full rounded-lg py-1 text-sm",
+          myFollowInfo ? "secondary-btn" : "primary-btn"
+        )}
+        disabled={loading}
+        onClick={myFollowInfo ? handleUnFollow : handleFollow}
+      >
+        {myFollowInfo ? "언팔로우" : "팔로우"}
+      </button>
+    </article>
+  );
+}

--- a/src/components/Profile/FollowingUser.tsx
+++ b/src/components/Profile/FollowingUser.tsx
@@ -72,7 +72,7 @@ export default function FollowingUser({ user, myFollowInfo }: FollowingUser) {
 
   return (
     <article
-      className="w-28 flex flex-col items-center gap-1 cursor-pointer overflow-hidden"
+      className="w-28 shrink-0 flex flex-col items-center gap-1 cursor-pointer overflow-hidden"
       onClick={() => navigate(`/user/${user.user}`)}
     >
       <img

--- a/src/components/Profile/FollowingUser.tsx
+++ b/src/components/Profile/FollowingUser.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import { useState } from "react";
 import { createNotification } from "../../api/notification";
 import { deleteFollow, postFollow } from "../../api/follow";
+import defaultProfileImg from "../../../public/logo.png";
 
 interface FollowingUser {
   user: Follow;
@@ -64,7 +65,7 @@ export default function FollowingUser({ user, myFollowInfo }: FollowingUser) {
       onClick={() => navigate(`/user/${user.user}`)}
     >
       <img
-        src={userInfo?.image ?? "/logo.png"}
+        src={userInfo?.image ?? defaultProfileImg}
         alt="프로필 이미지"
         className="w-24 h-24 profile rounded-full"
       />

--- a/src/components/Profile/PostCardGridSection.tsx
+++ b/src/components/Profile/PostCardGridSection.tsx
@@ -1,10 +1,29 @@
 import PostCard from "../common/PostCard";
 
-export default function PostCardGridSection({ posts }: { posts: Post[] }) {
+interface PostCardGridSectionProps {
+  fullName: string;
+  posts: Post[];
+  isMyProfile?: boolean;
+}
+
+export default function PostCardGridSection({
+  fullName,
+  posts,
+  isMyProfile = false,
+}: PostCardGridSectionProps) {
   return (
     <section className="pb-10 w-[934px] grow">
+      <h2 className="text-2xl font-semibold mb-6">
+        {isMyProfile ? (
+          <>나의 포스트</>
+        ) : (
+          <>
+            <span className="text-highlight">{fullName}</span>님의 포스트
+          </>
+        )}
+      </h2>
       {posts.length === 0 ? (
-        <div className="flex items-center justify-center h-full">
+        <div className="flex items-center justify-center mt-20">
           <p className="text-lg text-center">현재 작성된 포스트가 없습니다.</p>
         </div>
       ) : (

--- a/src/components/Profile/ProfileSection.tsx
+++ b/src/components/Profile/ProfileSection.tsx
@@ -19,11 +19,14 @@ export default function ProfileSection({
   const navigate = useNavigate();
   const [isFollow, setIsFollow] = useState(false);
   const [loading, setLoading] = useState(false);
-  const { isLoggedIn } = useAuthStore();
   const [followersCount, setFollowersCount] = useState(
     user?.followers.length || 0
   ); // 팔로워 수 상태 추가
   const [followId, setFollowId] = useState<string | null>(null);
+
+  const deleteFollowing = useAuthStore((state) => state.deleteFollowing);
+  const addFollowing = useAuthStore((state) => state.addFollowing);
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const myId = useAuthStore((state) => state.user)?._id;
 
   useEffect(() => {
@@ -52,6 +55,7 @@ export default function ProfileSection({
       setIsFollow(false);
       setFollowersCount((prevCount) => Math.max(prevCount - 1, 0));
       setFollowId(null);
+      deleteFollowing(followId);
     } catch (err) {
       console.error("언팔로우 요청 실패:", err);
       // 실패 시 상태 롤백
@@ -74,6 +78,7 @@ export default function ProfileSection({
       setIsFollow(true);
       setFollowersCount((prevCount) => prevCount + 1);
       setFollowId(data._id);
+      addFollowing(data);
 
       await createNotification({
         notificationType: "FOLLOW",
@@ -93,7 +98,7 @@ export default function ProfileSection({
   };
 
   return (
-    <article className="border-b border-gray-ee dark:border-gray-ee/50 flex justify-center items-center gap-20 mb-10 p-10 w-full">
+    <article className="border-b border-gray-ee dark:border-gray-ee/50 flex justify-center items-center gap-20 p-10 w-full">
       <UserAvatar name={user?.fullName} image={user?.image} />
       <section className="w-max">
         <div className="flex w-[208px] justify-between mb-4">
@@ -135,7 +140,7 @@ export default function ProfileSection({
               type="button"
               className={twMerge(
                 "w-full py-1 rounded-lg text-sm font-medium",
-                isFollow ? "secondary-btn" : "primary-btn",
+                isFollow ? "secondary-btn" : "primary-btn"
               )}
               onClick={isFollow ? handleUnfollow : handleFollow}
               disabled={loading}

--- a/src/hooks/useCarouselButtons.tsx
+++ b/src/hooks/useCarouselButtons.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react";
+import { EmblaCarouselType } from "embla-carousel";
+
+type UsePrevNextButtonsType = {
+  prevBtnDisabled: boolean;
+  nextBtnDisabled: boolean;
+  onPrevButtonClick: () => void;
+  onNextButtonClick: () => void;
+};
+
+export const useCarouselButtons = (
+  emblaApi: EmblaCarouselType | undefined
+): UsePrevNextButtonsType => {
+  const [prevBtnDisabled, setPrevBtnDisabled] = useState(true);
+  const [nextBtnDisabled, setNextBtnDisabled] = useState(true);
+
+  const onPrevButtonClick = useCallback(() => {
+    if (!emblaApi) return;
+    emblaApi.scrollPrev();
+    //emblaApi.scrollTo(-3); // 한 번에 3개의 슬라이드를 이동
+  }, [emblaApi]);
+
+  const onNextButtonClick = useCallback(() => {
+    if (!emblaApi) return;
+    emblaApi.scrollNext();
+    //emblaApi.scrollTo(-3); // 한 번에 3개의 슬라이드를 이동
+  }, [emblaApi]);
+
+  const onSelect = useCallback((emblaApi: EmblaCarouselType) => {
+    setPrevBtnDisabled(!emblaApi.canScrollPrev());
+    setNextBtnDisabled(!emblaApi.canScrollNext());
+  }, []);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    onSelect(emblaApi);
+    emblaApi.on("reInit", onSelect).on("select", onSelect);
+  }, [emblaApi, onSelect]);
+
+  return {
+    prevBtnDisabled,
+    nextBtnDisabled,
+    onPrevButtonClick,
+    onNextButtonClick,
+  };
+};

--- a/src/hooks/useCarouselButtons.tsx
+++ b/src/hooks/useCarouselButtons.tsx
@@ -17,13 +17,11 @@ export const useCarouselButtons = (
   const onPrevButtonClick = useCallback(() => {
     if (!emblaApi) return;
     emblaApi.scrollPrev();
-    //emblaApi.scrollTo(-3); // 한 번에 3개의 슬라이드를 이동
   }, [emblaApi]);
 
   const onNextButtonClick = useCallback(() => {
     if (!emblaApi) return;
     emblaApi.scrollNext();
-    //emblaApi.scrollTo(-3); // 한 번에 3개의 슬라이드를 이동
   }, [emblaApi]);
 
   const onSelect = useCallback((emblaApi: EmblaCarouselType) => {

--- a/src/pages/MyProfile.tsx
+++ b/src/pages/MyProfile.tsx
@@ -41,8 +41,12 @@ export default function MyProfile() {
 
   return (
     <section className="w-[934px] mx-auto flex flex-col items-center">
-      <ProfileSection user={user} isMyProfile={true} />
-      <PostCardGridSection posts={user.posts} />
+      <ProfileSection user={user} isMyProfile />
+      <PostCardGridSection
+        fullName={user.fullName}
+        posts={user.posts}
+        isMyProfile
+      />
     </section>
   );
 }

--- a/src/pages/MyProfile.tsx
+++ b/src/pages/MyProfile.tsx
@@ -4,12 +4,14 @@ import PostCardGridSection from "../components/Profile/PostCardGridSection";
 import ProfileSection from "../components/Profile/ProfileSection";
 import { useAuthStore } from "../store/authStore";
 import Loading from "../components/common/Loading";
+import FollowingSection from "../components/Profile/FollowingSection";
 
 export default function MyProfile() {
   // User 정보 가져오기
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const updateUser = useAuthStore((state) => state.updateUser);
   const myId = useAuthStore((state) => state.user)?._id;
 
   useEffect(() => {
@@ -18,6 +20,7 @@ export default function MyProfile() {
         setLoading(true);
         const { data } = await axiosInstance.get<User>(`/users/${myId}`);
         setUser(data);
+        updateUser(data);
       } catch (err) {
         console.error(err);
         setError("사용자 정보를 불러오는 데 실패했습니다.");
@@ -40,8 +43,13 @@ export default function MyProfile() {
     );
 
   return (
-    <section className="w-[934px] mx-auto flex flex-col items-center">
+    <section className="w-[934px] mx-auto flex flex-col items-center gap-10">
       <ProfileSection user={user} isMyProfile />
+      <FollowingSection
+        fullName={user.fullName}
+        followingList={user.following}
+        isMyProfile
+      />
       <PostCardGridSection
         fullName={user.fullName}
         posts={user.posts}

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -5,6 +5,7 @@ import ProfileSection from "../components/Profile/ProfileSection";
 import { axiosInstance } from "../api/axios";
 import { useAuthStore } from "../store/authStore";
 import Loading from "../components/common/Loading";
+import FollowingSection from "../components/Profile/FollowingSection";
 
 export default function UserProfile() {
   const [profileUser, setProfileUser] = useState<User | null>(null);
@@ -43,8 +44,12 @@ export default function UserProfile() {
 
   if (checkIsMyUserId(userId!)) return <Navigate to="/mypage" replace />;
   return (
-    <section className="w-fit mx-auto flex flex-col items-center">
+    <section className="w-fit mx-auto flex flex-col items-center gap-10">
       <ProfileSection user={profileUser} />
+      <FollowingSection
+        fullName={profileUser.fullName}
+        followingList={profileUser.following}
+      />
       <PostCardGridSection
         fullName={profileUser.fullName}
         posts={profileUser.posts}

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -45,7 +45,10 @@ export default function UserProfile() {
   return (
     <section className="w-fit mx-auto flex flex-col items-center">
       <ProfileSection user={profileUser} />
-      <PostCardGridSection posts={profileUser.posts} />
+      <PostCardGridSection
+        fullName={profileUser.fullName}
+        posts={profileUser.posts}
+      />
     </section>
   );
 }

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -43,8 +43,9 @@ export default function UserProfile() {
   }
 
   if (checkIsMyUserId(userId!)) return <Navigate to="/mypage" replace />;
+
   return (
-    <section className="w-fit mx-auto flex flex-col items-center gap-10">
+    <section className="w-[934px] mx-auto flex flex-col items-center gap-10">
       <ProfileSection user={profileUser} />
       <FollowingSection
         fullName={profileUser.fullName}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,21 +1,18 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-interface RequiredUser {
-  _id: string;
-  image: string | null;
-  fullName: string;
-}
-
 interface AuthStore {
   isLoggedIn: boolean;
   accessToken: string | null;
-  user: RequiredUser | null;
+  user: User | null;
   checkIsMyUserId: (id: string) => boolean;
-  login: (accessToken: string, user: RequiredUser) => void;
+  login: (accessToken: string, user: User) => void;
   logout: () => void;
+  updateUser: (user: User) => void;
   updateUserImage: (image: string) => void;
   updateUserFullName: (fullName: string) => void;
+  deleteFollowing: (followId: string) => void;
+  addFollowing: (followInfo: Follow) => void;
 }
 
 export const useAuthStore = create<AuthStore>()(
@@ -25,9 +22,14 @@ export const useAuthStore = create<AuthStore>()(
       accessToken: null,
       user: null,
       checkIsMyUserId: (id) => id === get().user?._id,
-      login: (accessToken: string, user: RequiredUser) =>
+      login: (accessToken: string, user: User) =>
         set({ isLoggedIn: true, accessToken, user }),
       logout: () => set({ isLoggedIn: false, accessToken: null, user: null }),
+      updateUser: (user: User) =>
+        set((state) => ({
+          ...state,
+          user,
+        })),
       updateUserImage: (image: string) =>
         set((state) => ({
           user: state.user ? { ...state.user, image } : null,
@@ -35,6 +37,26 @@ export const useAuthStore = create<AuthStore>()(
       updateUserFullName: (fullName: string) =>
         set((state) => ({
           user: state.user ? { ...state.user, fullName } : null,
+        })),
+      deleteFollowing: (followId: string) =>
+        set((state) => ({
+          user: state.user
+            ? {
+                ...state.user,
+                following: state.user.following.filter(
+                  ({ _id }) => _id !== followId
+                ),
+              }
+            : null,
+        })),
+      addFollowing: (followInfo: Follow) =>
+        set((state) => ({
+          user: state.user
+            ? {
+                ...state.user,
+                following: [...state.user.following, followInfo],
+              }
+            : null,
         })),
     }),
     {

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -23,20 +23,8 @@ interface User {
   posts: Post[];
   likes: Like[];
   comments: string[];
-  followers: {
-    _id: string;
-    user: string;
-    follower: string;
-    createdAt: string;
-    updatedAt: string;
-  }[];
-  following: {
-    _id: string;
-    user: string;
-    follower: string;
-    createdAt: string;
-    updatedAt: string;
-  }[];
+  followers: Follow[];
+  following: Follow[];
   notifications: Notification[];
   messages: Message[];
   _id: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,6 +849,24 @@ electron-to-chromium@^1.5.41:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.71.tgz"
   integrity sha512-dB68l59BI75W1BUGVTAEJy45CEVuEGy9qPVVQ8pnHyHMn36PLPPoE1mjLH+lo9rKulO3HC2OhbACI/8tCqJBcA==
 
+embla-carousel-react@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-8.5.1.tgz#e06ff28cb53698d453ffad89423c23d725e9b010"
+  integrity sha512-z9Y0K84BJvhChXgqn2CFYbfEi6AwEr+FFVVKm/MqbTQ2zIzO1VQri6w67LcfpVF0AjbhwVMywDZqY4alYkjW5w==
+  dependencies:
+    embla-carousel "8.5.1"
+    embla-carousel-reactive-utils "8.5.1"
+
+embla-carousel-reactive-utils@8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.5.1.tgz#3059ab2f72f04988a96694f700a772a72bb75ffb"
+  integrity sha512-n7VSoGIiiDIc4MfXF3ZRTO59KDp820QDuyBDGlt5/65+lumPHxX2JLz0EZ23hZ4eg4vZGUXwMkYv02fw2JVo/A==
+
+embla-carousel@8.5.1, embla-carousel@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-8.5.1.tgz#8d83217e831666f6df573b0d3727ff0ae9208002"
+  integrity sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"


### PR DESCRIPTION
## 작업 내용
### 구현 관련
- 마이페이지와 유저 프로필 페이지에 팔로잉 목록이 보여지도록 구현했습니다.
- 캐러셀 라이브러리로 Embla Carousel를 선택했습니다. (이게 간단하대요!!)

### 스타일 관련
- 섹션이 하나 추가되어 간격을 약간 조정했습니다.

## 수정사항
- useAuthStore에서 기존의 필수 데이터만 저장하고 있던 방식에서 전체 데이터를 저장하는 방식으로 수정했습니다.
  - 현재 로그인한 유저의 팔로잉 목록을 갖고 있어야 팔로잉 여부를 판단할 수 있는 상황이었습니다.
  - 어차피 전체 유저 목록도 persist로 갖고 있는 마당에, 로그인한 유저도 그래도 되겠다... 싶었습니다.
  - 유저 정보는 처음 로그인할 때와 마이페이지에 접근할 때만 전체 업데이트를 진행하도록 구현했습니다.
  - 팔로잉 목록들은 필터링으로 제거하거나 추가하는 방식으로 구현했습니다.

## Embla Carousel 라이브러리
react-slick이 유명하긴 하나, embla도 많이 떠오르는 라이브러리라고 해서 적용해보고 싶었습니다...ㅎ
![image](https://github.com/user-attachments/assets/d3411d21-292e-49f9-857c-6cad5300aceb)

## 구현 영상
원래 3개씩 슬라이드 되는건데 팔로잉을 너무 적게해서 3개씩 움직이는 걸 못 찍었습니다...!
https://github.com/user-attachments/assets/cddd00bd-c672-4006-9589-973321d2618a

